### PR TITLE
Introduce goreleaser for provider versioning and github releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+# Usage notes:
+#   tag new release with:
+#     git tag vx.x.x
+#    build and push with:
+#      GPG_FINGERPRINT="<key-fingerprint>" GITHUB_TOKEN="<token>" goreleaser release --rm-dist
+#
+before:
+  hooks:
+    - git update-index --refresh && git diff-index --quiet HEAD --
+builds:
+- env:
+    # goreleaser does not work with CGO, it could also complicate
+    # usage by users in CI/CD systems like Terraform Cloud where
+    # they are unable to install libraries.
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.tag={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+#    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+#    - '386'
+#    - arm
+    - arm64
+#  ignore:
+#    - goos: darwin
+#      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  # If you want to manually examine the release before its live, uncomment this line:
+  draft: true
+changelog:
+  skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X buildonaws.tag={{.Version}} -X buildonaws.commit={{.Commit}}'
+    - '-s -w -X terraform-provider-buildonaws/buildonaws.tag={{.Version}} -X terraform-provider-buildonaws/buildonaws.commit={{.Commit}}'
   goos:
 #    - freebsd
     - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.tag={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X buildonaws.tag={{.Version}} -X buildonaws.commit={{.Commit}}'
   goos:
 #    - freebsd
     - windows

--- a/buildonaws/provider.go
+++ b/buildonaws/provider.go
@@ -19,18 +19,30 @@ import (
 )
 
 var (
-	_ provider.Provider = &buildOnAWSProvider{}
+	_           provider.Provider = &buildOnAWSProvider{}
+	commit, tag string            // populated by goreleaser
+)
+
+const (
+	defaultVersion = "0.0.0"
+	defaultCommit  = "devel"
 )
 
 func New() provider.Provider {
-	return &buildOnAWSProvider{}
+	return &buildOnAWSProvider{
+		Version: version(),
+		Commit:  shortCommit(),
+	}
 }
 
 type buildOnAWSProvider struct {
+	Version string
+	Commit  string
 }
 
 func (p *buildOnAWSProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = providerName
+	resp.Version = p.Version
 }
 
 func (p *buildOnAWSProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -118,4 +130,19 @@ func (p *buildOnAWSProvider) Resources(_ context.Context) []func() resource.Reso
 	return []func() resource.Resource{
 		NewCharacterResource,
 	}
+}
+
+func shortCommit() string {
+	if len(commit) > 7 {
+		return commit[:8]
+	} else {
+		return defaultCommit
+	}
+}
+
+func version() string {
+	if tag == "" {
+		return defaultVersion
+	}
+	return tag
 }

--- a/buildonaws/provider.go
+++ b/buildonaws/provider.go
@@ -30,19 +30,19 @@ const (
 
 func New() provider.Provider {
 	return &buildOnAWSProvider{
-		Version: version(),
-		Commit:  shortCommit(),
+		version: version(),
+		commit:  shortCommit(),
 	}
 }
 
 type buildOnAWSProvider struct {
-	Version string
-	Commit  string
+	version string
+	commit  string
 }
 
 func (p *buildOnAWSProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = providerName
-	resp.Version = p.Version
+	resp.Version = p.version
 }
 
 func (p *buildOnAWSProvider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}


### PR DESCRIPTION
Hey Ricardo, I saw your project on Mastodon and I appreciate your efforts in this regard. Good examples of what to do with the new framework are hard to come by!

This PR introduces goreleaser to the project.

The project will still continue to build in the usual way, but when the project is tagged (`git tag vX.X.X`)  and goreleaser is run (see comments at the top of `.goreleaser.yml` - this operation requires a GPG key and github API token), goreleaser will:

- build binaries for various OS/architecture combinations
- package those binaries with a manifest file, suitable for consumption by the terraform registry
- sign the packaged binaries (required by the terraform registry)
- upload the results to the github releases page [like this](https://github.com/chrismarget/custom-provider-with-terraform-plugin-framework/releases). This is where the registry expects to find the provider.

goreleaser also populates `tag` and `commit` variables which get carried around by the provider struct. These can be useful for diagnostics, and are used to set `provider.MetadataResponse.Version` in `provider.Metadata()`.
