### PR TITLE
Add provider attribute to control TLS certificate validation.

### DIFF
--- a/buildonaws/shared.go
+++ b/buildonaws/shared.go
@@ -10,12 +10,14 @@ import (
 )
 
 var (
-	providerTypeName        = "buildonaws"
-	backendIndex            = providerTypeName
-	providerDesc            = "Provider to manage characters from comic books."
-	backendAddressField     = "backend_address"
-	backendAddressFieldDesc = "Address to connect to the OpenSearch backend."
-	backendAddressDefault   = "http://localhost:9200"
+	providerTypeName           = "buildonaws"
+	backendIndex               = providerTypeName
+	providerDesc               = "Provider to manage characters from comic books."
+	backendAddressField        = "backend_address"
+	backendAddressFieldDesc    = "Address to connect to the OpenSearch backend."
+	backendAddressDefault      = "http://localhost:9200"
+	skipTLSValidationField     = "skip_tls_validation"
+	skipTLSValidationFieldDesc = "Allows TLS connection to OpenSearch backend running with untrusted certificate."
 )
 
 var (

--- a/buildonaws/types.go
+++ b/buildonaws/types.go
@@ -3,7 +3,8 @@ package buildonaws
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type BuildOnAWSProviderModel struct {
-	BackendAddress types.String `tfsdk:"backend_address"`
+	BackendAddress    types.String `tfsdk:"backend_address"`
+	SkipTLSValidation types.Bool   `tfsdk:"skip_tls_validation"`
 }
 
 type CharacterDataSourceModel struct {

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,3 +24,4 @@ provider "buildonaws" {
 ### Optional
 
 - `backend_address` (String) Address to connect to the OpenSearch backend.
+- `skip_tls_validation` (Boolean) Allows TLS connection to OpenSearch backend running with untrusted certificate.


### PR DESCRIPTION
Hi Ricardo,

This PR adds a provider config attribute to control TLS validation.

It's not strictly necessary because the docker container doesn't expose a TLS listener, but forcing `InsecureSkipVerify: true` was a bit of an eyebrow-raiser. Deleting [line 106](https://github.com/build-on-aws/custom-provider-with-terraform-plugin-framework/blob/ce1f2162aa76b01f8ab69f0199c8085b2a0c1f0f/buildonaws/provider.go#L106) altogether might also be reasonable (I'm unfamiliar with the service, so not clear whether un-validated TLS connections are likely to be encountered).

At any rate, this is one option to make insecure connections possible, while providing safe/sane default behavior. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
